### PR TITLE
Extend CSS to fix issue with menu item truncation

### DIFF
--- a/src/ciyam_interface.css
+++ b/src/ciyam_interface.css
@@ -482,7 +482,7 @@ a
    border-left: 1px solid  #666;
    border-left: 1px solid  rgba(230,230,230,0.6);
    font-weight: 300;
-   height: 30px;
+   max-height: 60px;
    line-height: 30px;
    padding-top: 60px;
    padding-bottom: 20px;

--- a/src/ciyam_interface.css
+++ b/src/ciyam_interface.css
@@ -482,7 +482,7 @@ a
    border-left: 1px solid  #666;
    border-left: 1px solid  rgba(230,230,230,0.6);
    font-weight: 300;
-   max-height: 60px;
+
    line-height: 30px;
    padding-top: 60px;
    padding-bottom: 20px;


### PR DESCRIPTION
enables menu items to not truncate over 1 line long.